### PR TITLE
Linux improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ flutter pub add wireguard_flutter
 Initialize a wireguard instance with a name using `initialize`:
 
 ```dart
-final wireguard = WireGuardFlutter();
+final wireguard = WireGuardFlutter.instance;
 
 // initialize the interface
 await wireguard.initialize(interfaceName: 'wg0');

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A flutter plugin to setup and control VPN connection via [Wireguard](https://www
   - [Disconnect](#disconnect)
   - [Stage](#stage)
 - [Supported Platforms](#supported-platforms)
+- [FAQ & Troubleshooting](#faq--troubleshooting)
 
 
 ## Usage
@@ -20,7 +21,7 @@ flutter pub add wireguard_flutter
 
 ### Initialize
 
-Initialize a wireguard instance with a name using `initialize`:
+Initialize a wireguard instance with a valid name using `initialize`:
 
 ```dart
 final wireguard = WireGuardFlutter.instance;
@@ -83,19 +84,37 @@ Or get the current stage using `getStage`:
 final stage = await wireguard.stage();
 ```
 
+The available stages are:
+
+| Code | Description |
+| ---- | ----------- |
+| connecting | The interface is connecting |
+| connected | The interface is connected |
+| disconnecting | The interface is disconnecting |
+| disconnected | The interface is disconnected |
+| waitingConnection | Waiting for a user interaction |
+| authenticating | Authenticating with the server |
+| reconnect | Reconnecting the the interface |
+| noConnection | Any connection has not been made |
+| preparing | Preparing to connect |
+| denied | The connection has been denied by the system, usually by refused permissions |
+| exiting | Exiting the interface |
+
 ## Supported Platforms
 
 |             | Android | iOS   | macOS | Windows | Linux |
 | ----------- | ------- | ----- | ----- | ------- | ----- |
-| **Version** | SDK 21+     | 15.0+ | 12+   | 7+      | Any   |
+| **Version** | SDK 21+ | 15.0+ | 12+   | 7+      | Any   |
 
 ### Windows
 
-On Windows, the app must be run as administrator to be able to create and manipulate the tunnel. To debug the app, run `flutter run` from an elevated command prompt. To run the app normally, the system will request your app to be run as administrator. No changes in the code are required.
+On Windows, the app must be run as administrator to be able to create and manipulate the tunnel. To debug the app, run `flutter run` from an elevated command prompt. To run the app normally, the system will request your app to be run as administrator. No code changes or external dependencies are required.
 
 ### Linux
 
-On Linux, the app must be run as a root user to be able to create and manipulate the tunnel. The required dependencies need to be installed: `wireguard` and `wireguard-tools`.
+#### Install dependencies
+
+The required dependencies need to be installed: `wireguard` and `wireguard-tools`.
 
 On Ubuntu/Debian, use the following command to install the dependencies:
 
@@ -105,7 +124,21 @@ sudo apt install wireguard wireguard-tools openresolv
 
 For other Linux distros, see [this](https://www.wireguard.com/install/).
 
+> [!NOTE]  
+> 
+> If `openresolv` is not installed in the system, configuration files with a DNS provided may not connect. See [this issue](#linux-error-resolvconf-command-not-found) for more information.
+
+#### Initializing
+
+When `wireguard.initialize` is called, the application will request your user password (`[sudo] password for <user>:`). This is necessary because wireguard must run as a root to be able to create AND manipulate the tunnels. This is true for either debug and release modes or a distributed executable.
+
+> [!CAUTION]
+>
+> Do not run the app in root mode (e.g `sudo ./executable`, `sudo flutter run`), otherwise the connection will not be established.
+
 ## FAQ & Troubleshooting
+
+### Linux error `resolvconf: command not found`
 
 On Linux, you may receive the error `resolvconf: command not found`. This is because wireguard tried to adjust the nameserver. Make sure to install `openresolv` or not provide the "DNS" field.
 

--- a/README.md
+++ b/README.md
@@ -1,18 +1,93 @@
 # wireguard_flutter
 
-forks from [mysteriumnetwork](https://github.com/mysteriumnetwork/wireguard_dart/) tunnel
 A flutter plugin to setup and control VPN connection via [Wireguard](https://www.wireguard.com/) tunnel.
 
-|             | Android | iOS   | macOS | Windows | Linux |
-| ----------- | ------- | ----- | ----- | ------- | ----- |
-| **Support** | 21+     | 15.0+ | 12+   | 7+      | Any   |
+- [Usage](#usage)
+  - [Initialize](#initialize)
+  - [Connect](#connect)
+  - [Disconnect](#disconnect)
+  - [Stage](#stage)
+- [Supported Platforms](#supported-platforms)
+
 
 ## Usage
 
 To use this plugin, add `wireguard_flutter` or visit [Flutter Tutorial](https://flutterflux.com/).
 
-"WireGuard" is a registered trademark of Jason A. Donenfeld.
+```
+flutter pub add wireguard_flutter
+```
 
+### Initialize
+
+Initialize a wireguard instance with a name using `initialize`:
+
+```dart
+final wireguard = WireGuardFlutter();
+
+// initialize the interface
+await wireguard.initialize(interfaceName: 'wg0');
+```
+
+and declare the `.conf` data:
+```dart
+const String conf = '''[Interface]
+PrivateKey = 0IZmHsxiNQ54TsUs0EQ71JNsa5f70zVf1LmDvON1CXc=
+Address = 10.8.0.4/32
+DNS = 1.1.1.1
+
+
+[Peer]
+PublicKey = 6uZg6T0J1bHuEmdqPx8OmxQ2ebBJ8TnVpnCdV8jHliQ=
+PresharedKey = As6JiXcYcqwjSHxSOrmQT13uGVlBG90uXZWmtaezZVs=
+AllowedIPs = 0.0.0.0/0, ::/0
+PersistentKeepalive = 0
+Endpoint = 38.180.13.85:51820''';
+```
+
+For more info on the configuration data, see [the documentation](https://man7.org/linux/man-pages/man8/wg-quick.8.html) with examples.
+
+### Connect
+
+After initializing, connect using `startVpn`:
+
+```dart
+await wireguard.startVpn(
+  serverAddress: address, // the server address (e.g 'demo.wireguard.com:51820')
+  wgQuickConfig: conf, // the quick-config file
+  providerBundleIdentifier: 'com.example', // your app identifier
+);
+```
+
+### Disconnect
+
+After connecting, disconnect using `stopVpn`:
+
+```dart
+await wireguard.stopVpn();
+```
+
+### Stage
+
+Listen to stage change using `vpnStageSnapshot`:
+
+```dart
+wireguard.vpnStageSnapshot.listen((event) {
+  debugPrint("status changed $event");
+});
+```
+
+Or get the current stage using `getStage`:
+
+```dart
+final stage = await wireguard.stage();
+```
+
+## Supported Platforms
+
+|             | Android | iOS   | macOS | Windows | Linux |
+| ----------- | ------- | ----- | ----- | ------- | ----- |
+| **Version** | SDK 21+     | 15.0+ | 12+   | 7+      | Any   |
 
 ### Windows
 
@@ -33,3 +108,9 @@ For other Linux distros, see [this](https://www.wireguard.com/install/).
 ## FAQ & Troubleshooting
 
 On Linux, you may receive the error `resolvconf: command not found`. This is because wireguard tried to adjust the nameserver. Make sure to install `openresolv` or not provide the "DNS" field.
+
+---
+
+"WireGuard" is a registered trademark of Jason A. Donenfeld.
+
+Fork from [mysteriumnetwork](https://github.com/mysteriumnetwork/wireguard_dart/) tunnel.

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:developer' as developer;
 
 import 'package:flutter/material.dart';
 import 'package:wireguard_flutter/wireguard_flutter.dart';
@@ -18,33 +17,23 @@ class MyApp extends StatefulWidget {
 class _MyAppState extends State<MyApp> {
   final wireGuardFlutter = WireGuardFlutter();
 
+  late String name;
+
   @override
   void initState() {
     super.initState();
     wireGuardFlutter.vpnStageSnapshot().listen((event) {
       debugPrint("status changed $event");
     });
+    name = 'wg_vpn';
   }
 
-  late String name;
-  // String get _randomName =>
-  //     'wg_vpn_${DateTime.now().millisecondsSinceEpoch.toStringAsFixed(3).replaceAll('.', '_')}';
-
   Future<void> initialize() async {
-    // name = _randomName;
-    name = 'wg_vpn';
     try {
-      await wireGuardFlutter.initialize(
-        localizedDescription: name,
-        win32ServiceName: name,
-      );
+      await wireGuardFlutter.initialize(interfaceName: name);
       debugPrint("initialize success");
-    } catch (e) {
-      debugPrint("failed to initialize success $e");
-      developer.log(
-        'Setup tunnel',
-        error: e,
-      );
+    } catch (error, stack) {
+      debugPrint("failed to initialize: $error\n$stack");
     }
   }
 
@@ -54,15 +43,9 @@ class _MyAppState extends State<MyApp> {
         serverAddress: '167.235.55.239:51820',
         wgQuickConfig: conf,
         providerBundleIdentifier: 'com.billion.wireguardvpn.WGExtension',
-        localizedDescription: 'wg_example',
-        win32ServiceName: name,
       );
-    } catch (e) {
-      debugPrint("failed to start $e");
-      developer.log(
-        'startVpn tunnel',
-        error: e.toString(),
-      );
+    } catch (error, stack) {
+      debugPrint("failed to start $error\n$stack");
     }
   }
 
@@ -70,11 +53,7 @@ class _MyAppState extends State<MyApp> {
     try {
       await wireGuardFlutter.stopVpn();
     } catch (e, str) {
-      debugPrint('$e\n$str');
-      developer.log(
-        'Disconnect',
-        error: e.toString(),
-      );
+      debugPrint('Failed to disconnect $e\n$str');
     }
   }
 
@@ -90,7 +69,7 @@ class _MyAppState extends State<MyApp> {
     return MaterialApp(
       home: Scaffold(
         appBar: AppBar(
-          title: const Text('WireGurad example app'),
+          title: const Text('WireGuard Example App'),
         ),
         body: Container(
           constraints: const BoxConstraints.expand(),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -31,9 +31,9 @@ class _MyAppState extends State<MyApp> {
   @override
   void initState() {
     super.initState();
-//    wireguard.vpnStageSnapshot.listen((event) {
-//      debugPrint("status changed $event");
-//    });
+    wireguard.vpnStageSnapshot.listen((event) {
+      debugPrint("status changed $event");
+    });
     name = 'wg_vpn';
   }
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -4,7 +4,16 @@ import 'package:flutter/material.dart';
 import 'package:wireguard_flutter/wireguard_flutter.dart';
 
 void main() {
-  runApp(const MyApp());
+  runApp(
+    MaterialApp(
+      home: Scaffold(
+        appBar: AppBar(
+          title: const Text('WireGuard Example App'),
+        ),
+        body: const MyApp(),
+      ),
+    ),
+  );
 }
 
 class MyApp extends StatefulWidget {
@@ -15,22 +24,22 @@ class MyApp extends StatefulWidget {
 }
 
 class _MyAppState extends State<MyApp> {
-  final wireGuardFlutter = WireGuardFlutter();
+  final wireguard = WireGuardFlutter();
 
   late String name;
 
   @override
   void initState() {
     super.initState();
-    wireGuardFlutter.vpnStageSnapshot().listen((event) {
-      debugPrint("status changed $event");
-    });
+//    wireguard.vpnStageSnapshot.listen((event) {
+//      debugPrint("status changed $event");
+//    });
     name = 'wg_vpn';
   }
 
   Future<void> initialize() async {
     try {
-      await wireGuardFlutter.initialize(interfaceName: name);
+      await wireguard.initialize(interfaceName: name);
       debugPrint("initialize success");
     } catch (error, stack) {
       debugPrint("failed to initialize: $error\n$stack");
@@ -39,7 +48,7 @@ class _MyAppState extends State<MyApp> {
 
   void startVpn() async {
     try {
-      await wireGuardFlutter.startVpn(
+      await wireguard.startVpn(
         serverAddress: '167.235.55.239:51820',
         wgQuickConfig: conf,
         providerBundleIdentifier: 'com.billion.wireguardvpn.WGExtension',
@@ -51,7 +60,7 @@ class _MyAppState extends State<MyApp> {
 
   void disconnect() async {
     try {
-      await wireGuardFlutter.stopVpn();
+      await wireguard.stopVpn();
     } catch (e, str) {
       debugPrint('Failed to disconnect $e\n$str');
     }
@@ -59,96 +68,89 @@ class _MyAppState extends State<MyApp> {
 
   void getStatus() {
     debugPrint("getting stage");
-    wireGuardFlutter.stage().then((value) {
+    wireguard.stage().then((value) {
       debugPrint("stage $value");
     });
   }
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      home: Scaffold(
-        appBar: AppBar(
-          title: const Text('WireGuard Example App'),
-        ),
-        body: Container(
-          constraints: const BoxConstraints.expand(),
-          padding: const EdgeInsets.all(16),
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            crossAxisAlignment: CrossAxisAlignment.center,
-            children: [
-              const SizedBox(height: 20),
-              TextButton(
-                onPressed: initialize,
-                style: ButtonStyle(
-                    minimumSize:
-                        MaterialStateProperty.all<Size>(const Size(100, 50)),
-                    padding: MaterialStateProperty.all(
-                        const EdgeInsets.fromLTRB(20, 15, 20, 15)),
-                    backgroundColor:
-                        MaterialStateProperty.all<Color>(Colors.blueAccent),
-                    overlayColor: MaterialStateProperty.all<Color>(
-                        Colors.white.withOpacity(0.1))),
-                child: const Text(
-                  'initialize',
-                  style: TextStyle(color: Colors.white),
-                ),
-              ),
-              const SizedBox(height: 20),
-              TextButton(
-                onPressed: startVpn,
-                style: ButtonStyle(
-                    minimumSize:
-                        MaterialStateProperty.all<Size>(const Size(100, 50)),
-                    padding: MaterialStateProperty.all(
-                        const EdgeInsets.fromLTRB(20, 15, 20, 15)),
-                    backgroundColor:
-                        MaterialStateProperty.all<Color>(Colors.blueAccent),
-                    overlayColor: MaterialStateProperty.all<Color>(
-                        Colors.white.withOpacity(0.1))),
-                child: const Text(
-                  'Connect',
-                  style: TextStyle(color: Colors.white),
-                ),
-              ),
-              const SizedBox(height: 20),
-              TextButton(
-                onPressed: disconnect,
-                style: ButtonStyle(
-                    minimumSize:
-                        MaterialStateProperty.all<Size>(const Size(100, 50)),
-                    padding: MaterialStateProperty.all(
-                        const EdgeInsets.fromLTRB(20, 15, 20, 15)),
-                    backgroundColor:
-                        MaterialStateProperty.all<Color>(Colors.blueAccent),
-                    overlayColor: MaterialStateProperty.all<Color>(
-                        Colors.white.withOpacity(0.1))),
-                child: const Text(
-                  'Disconnect',
-                  style: TextStyle(color: Colors.white),
-                ),
-              ),
-              const SizedBox(height: 20),
-              TextButton(
-                onPressed: getStatus,
-                style: ButtonStyle(
-                    minimumSize:
-                        MaterialStateProperty.all<Size>(const Size(100, 50)),
-                    padding: MaterialStateProperty.all(
-                        const EdgeInsets.fromLTRB(20, 15, 20, 15)),
-                    backgroundColor:
-                        MaterialStateProperty.all<Color>(Colors.blueAccent),
-                    overlayColor: MaterialStateProperty.all<Color>(
-                        Colors.white.withOpacity(0.1))),
-                child: const Text(
-                  'Get status',
-                  style: TextStyle(color: Colors.white),
-                ),
-              ),
-            ],
+    return Container(
+      constraints: const BoxConstraints.expand(),
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          const SizedBox(height: 20),
+          TextButton(
+            onPressed: initialize,
+            style: ButtonStyle(
+                minimumSize:
+                    MaterialStateProperty.all<Size>(const Size(100, 50)),
+                padding: MaterialStateProperty.all(
+                    const EdgeInsets.fromLTRB(20, 15, 20, 15)),
+                backgroundColor:
+                    MaterialStateProperty.all<Color>(Colors.blueAccent),
+                overlayColor: MaterialStateProperty.all<Color>(
+                    Colors.white.withOpacity(0.1))),
+            child: const Text(
+              'initialize',
+              style: TextStyle(color: Colors.white),
+            ),
           ),
-        ),
+          const SizedBox(height: 20),
+          TextButton(
+            onPressed: startVpn,
+            style: ButtonStyle(
+                minimumSize:
+                    MaterialStateProperty.all<Size>(const Size(100, 50)),
+                padding: MaterialStateProperty.all(
+                    const EdgeInsets.fromLTRB(20, 15, 20, 15)),
+                backgroundColor:
+                    MaterialStateProperty.all<Color>(Colors.blueAccent),
+                overlayColor: MaterialStateProperty.all<Color>(
+                    Colors.white.withOpacity(0.1))),
+            child: const Text(
+              'Connect',
+              style: TextStyle(color: Colors.white),
+            ),
+          ),
+          const SizedBox(height: 20),
+          TextButton(
+            onPressed: disconnect,
+            style: ButtonStyle(
+                minimumSize:
+                    MaterialStateProperty.all<Size>(const Size(100, 50)),
+                padding: MaterialStateProperty.all(
+                    const EdgeInsets.fromLTRB(20, 15, 20, 15)),
+                backgroundColor:
+                    MaterialStateProperty.all<Color>(Colors.blueAccent),
+                overlayColor: MaterialStateProperty.all<Color>(
+                    Colors.white.withOpacity(0.1))),
+            child: const Text(
+              'Disconnect',
+              style: TextStyle(color: Colors.white),
+            ),
+          ),
+          const SizedBox(height: 20),
+          TextButton(
+            onPressed: getStatus,
+            style: ButtonStyle(
+                minimumSize:
+                    MaterialStateProperty.all<Size>(const Size(100, 50)),
+                padding: MaterialStateProperty.all(
+                    const EdgeInsets.fromLTRB(20, 15, 20, 15)),
+                backgroundColor:
+                    MaterialStateProperty.all<Color>(Colors.blueAccent),
+                overlayColor: MaterialStateProperty.all<Color>(
+                    Colors.white.withOpacity(0.1))),
+            child: const Text(
+              'Get status',
+              style: TextStyle(color: Colors.white),
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -24,7 +24,7 @@ class MyApp extends StatefulWidget {
 }
 
 class _MyAppState extends State<MyApp> {
-  final wireguard = WireGuardFlutter();
+  final wireguard = WireGuardFlutter.instance;
 
   late String name;
 

--- a/lib/linux/wireguard_flutter_linux.dart
+++ b/lib/linux/wireguard_flutter_linux.dart
@@ -56,7 +56,7 @@ class WireGuardFlutterLinux extends WireGuardFlutterInterface {
   @override
   Future<void> stopVpn() async {
     assert(
-      configFile != null || (await isConnected()),
+      configFile != null && (await isConnected()),
       'Bad state: vpn has not been started. Call startVpn',
     );
     if (configFile != null) {

--- a/lib/linux/wireguard_flutter_linux.dart
+++ b/lib/linux/wireguard_flutter_linux.dart
@@ -21,11 +21,8 @@ class WireGuardFlutterLinux extends WireGuardFlutterInterface {
   final shell = Shell(runInShell: true, verbose: false);
 
   @override
-  Future<void> initialize({
-    String? localizedDescription,
-    String? win32ServiceName,
-  }) async {
-    name = localizedDescription;
+  Future<void> initialize({required String interfaceName}) async {
+    name = interfaceName;
     await refreshStage();
   }
 
@@ -52,7 +49,7 @@ class WireGuardFlutterLinux extends WireGuardFlutterInterface {
     if (isAlreadyConnected) return;
 
     _setStage(WireGuardFlutterInterface.vpnConnecting);
-    await shell.run('wg-quick up ${configFile!.path}');
+    await shell.run('sudo wg-quick up ${configFile!.path}');
     _setStage(WireGuardFlutterInterface.vpnConnected);
   }
 
@@ -64,7 +61,7 @@ class WireGuardFlutterLinux extends WireGuardFlutterInterface {
     );
     if (configFile != null) {
       _setStage(WireGuardFlutterInterface.vpnDisconnecting);
-      await shell.run('wg-quick down ${configFile!.path}');
+      await shell.run('sudo wg-quick down ${configFile!.path}');
       _setStage(WireGuardFlutterInterface.vpnDisconnected);
     }
   }

--- a/lib/linux/wireguard_flutter_linux.dart
+++ b/lib/linux/wireguard_flutter_linux.dart
@@ -11,7 +11,7 @@ class WireGuardFlutterLinux extends WireGuardFlutterInterface {
   String? name;
   File? configFile;
 
-  VpnStage? _stage;
+  VpnStage _stage = VpnStage.noConnection;
   final _stageController = StreamController<VpnStage>.broadcast();
   void _setStage(VpnStage stage) {
     _stage = stage;
@@ -86,7 +86,7 @@ class WireGuardFlutterLinux extends WireGuardFlutterInterface {
   }
 
   @override
-  Future<VpnStage> stage() async => _stage ?? VpnStage.noConnection;
+  Future<VpnStage> stage() async => _stage;
 
   @override
   Stream<VpnStage> get vpnStageSnapshot => _stageController.stream;

--- a/lib/linux/wireguard_flutter_linux.dart
+++ b/lib/linux/wireguard_flutter_linux.dart
@@ -69,14 +69,17 @@ class WireGuardFlutterLinux extends WireGuardFlutterInterface {
   @override
   Future<void> stopVpn() async {
     assert(
-      configFile != null && (await isConnected()),
+      (await isConnected()),
       'Bad state: vpn has not been started. Call startVpn',
     );
-    if (configFile != null) {
-      _setStage(WireGuardFlutterInterface.vpnDisconnecting);
-      await shell.run('sudo wg-quick down ${configFile!.path}');
-      _setStage(WireGuardFlutterInterface.vpnDisconnected);
+    _setStage(WireGuardFlutterInterface.vpnDisconnecting);
+    try {
+      await shell.run('sudo wg-quick down ${configFile?.path ?? name!}');
+    } catch (e) {
+      await refreshStage();
+      rethrow;
     }
+    await refreshStage();
   }
 
   @override

--- a/lib/linux/wireguard_flutter_linux.dart
+++ b/lib/linux/wireguard_flutter_linux.dart
@@ -22,7 +22,7 @@ class WireGuardFlutterLinux extends WireGuardFlutterInterface {
 
   @override
   Future<void> initialize({required String interfaceName}) async {
-    name = interfaceName;
+    name = interfaceName.replaceAll(' ', '_');
     await refreshStage();
   }
 

--- a/lib/linux/wireguard_flutter_linux.dart
+++ b/lib/linux/wireguard_flutter_linux.dart
@@ -71,7 +71,7 @@ class WireGuardFlutterLinux extends WireGuardFlutterInterface {
       _stage ?? WireGuardFlutterInterface.vpnNoConnection;
 
   @override
-  Stream<String> vpnStageSnapshot() => _stageController.stream;
+  Stream<String> get vpnStageSnapshot => _stageController.stream;
 
   @override
   Future<void> refreshStage() async {

--- a/lib/wireguard_flutter.dart
+++ b/lib/wireguard_flutter.dart
@@ -9,6 +9,10 @@ import 'wireguard_flutter_platform_interface.dart';
 class WireGuardFlutter extends WireGuardFlutterInterface {
   static WireGuardFlutterInterface? __instance;
   static WireGuardFlutterInterface get _instance => __instance!;
+  static WireGuardFlutterInterface get instance {
+    registerWith();
+    return _instance;
+  }
 
   static void registerWith() {
     if (__instance == null) {
@@ -22,9 +26,7 @@ class WireGuardFlutter extends WireGuardFlutterInterface {
     }
   }
 
-  WireGuardFlutter() {
-    registerWith();
-  }
+  WireGuardFlutter._();
 
   @override
   Stream<String> get vpnStageSnapshot => _instance.vpnStageSnapshot;

--- a/lib/wireguard_flutter.dart
+++ b/lib/wireguard_flutter.dart
@@ -6,6 +6,8 @@ import 'package:wireguard_flutter/wireguard_flutter_method_channel.dart';
 
 import 'wireguard_flutter_platform_interface.dart';
 
+export 'wireguard_flutter_platform_interface.dart' show VpnStage;
+
 class WireGuardFlutter extends WireGuardFlutterInterface {
   static WireGuardFlutterInterface? __instance;
   static WireGuardFlutterInterface get _instance => __instance!;

--- a/lib/wireguard_flutter.dart
+++ b/lib/wireguard_flutter.dart
@@ -31,14 +31,8 @@ class WireGuardFlutter extends WireGuardFlutterInterface {
   Stream<String> vpnStageSnapshot() => _instance.vpnStageSnapshot();
 
   @override
-  Future<void> initialize({
-    String? localizedDescription,
-    String? win32ServiceName,
-  }) {
-    return _instance.initialize(
-      localizedDescription: localizedDescription,
-      win32ServiceName: win32ServiceName,
-    );
+  Future<void> initialize({required String interfaceName}) {
+    return _instance.initialize(interfaceName: interfaceName);
   }
 
   @override
@@ -46,15 +40,11 @@ class WireGuardFlutter extends WireGuardFlutterInterface {
     required String serverAddress,
     required String wgQuickConfig,
     required String providerBundleIdentifier,
-    String? localizedDescription,
-    String? win32ServiceName,
   }) async {
     return _instance.startVpn(
       serverAddress: serverAddress,
       wgQuickConfig: wgQuickConfig,
       providerBundleIdentifier: providerBundleIdentifier,
-      localizedDescription: localizedDescription,
-      win32ServiceName: win32ServiceName,
     );
   }
 

--- a/lib/wireguard_flutter.dart
+++ b/lib/wireguard_flutter.dart
@@ -7,28 +7,27 @@ import 'package:wireguard_flutter/wireguard_flutter_method_channel.dart';
 import 'wireguard_flutter_platform_interface.dart';
 
 class WireGuardFlutter extends WireGuardFlutterInterface {
-  static bool _initialized = false;
-  static late WireGuardFlutterInterface _instance;
+  static WireGuardFlutterInterface? __instance;
+  static WireGuardFlutterInterface get _instance => __instance!;
 
   static void registerWith() {
-    _instance = WireGuardFlutter();
-  }
-
-  WireGuardFlutter() {
-    if (!_initialized) {
+    if (__instance == null) {
       if (kIsWeb) {
         throw UnsupportedError('The web platform is not supported');
       } else if (Platform.isLinux) {
-        _instance = WireGuardFlutterLinux();
+        __instance = WireGuardFlutterLinux();
       } else {
-        _instance = WireGuardFlutterMethodChannel();
+        __instance = WireGuardFlutterMethodChannel();
       }
-      _initialized = true;
     }
   }
 
+  WireGuardFlutter() {
+    registerWith();
+  }
+
   @override
-  Stream<String> vpnStageSnapshot() => _instance.vpnStageSnapshot();
+  Stream<String> get vpnStageSnapshot => _instance.vpnStageSnapshot;
 
   @override
   Future<void> initialize({required String interfaceName}) {

--- a/lib/wireguard_flutter.dart
+++ b/lib/wireguard_flutter.dart
@@ -7,6 +7,7 @@ import 'package:wireguard_flutter/wireguard_flutter_method_channel.dart';
 import 'wireguard_flutter_platform_interface.dart';
 
 class WireGuardFlutter extends WireGuardFlutterInterface {
+  static bool _initialized = false;
   static late WireGuardFlutterInterface _instance;
 
   static void registerWith() {
@@ -14,12 +15,15 @@ class WireGuardFlutter extends WireGuardFlutterInterface {
   }
 
   WireGuardFlutter() {
-    if (kIsWeb) {
-      throw UnsupportedError('The web platform is not supported');
-    } else if (Platform.isLinux) {
-      _instance = WireGuardFlutterLinux();
-    } else {
-      _instance = WireGuardFlutterMethodChannel();
+    if (!_initialized) {
+      if (kIsWeb) {
+        throw UnsupportedError('The web platform is not supported');
+      } else if (Platform.isLinux) {
+        _instance = WireGuardFlutterLinux();
+      } else {
+        _instance = WireGuardFlutterMethodChannel();
+      }
+      _initialized = true;
     }
   }
 

--- a/lib/wireguard_flutter.dart
+++ b/lib/wireguard_flutter.dart
@@ -29,7 +29,7 @@ class WireGuardFlutter extends WireGuardFlutterInterface {
   WireGuardFlutter._();
 
   @override
-  Stream<String> get vpnStageSnapshot => _instance.vpnStageSnapshot;
+  Stream<VpnStage> get vpnStageSnapshot => _instance.vpnStageSnapshot;
 
   @override
   Future<void> initialize({required String interfaceName}) {
@@ -56,5 +56,5 @@ class WireGuardFlutter extends WireGuardFlutterInterface {
   Future<void> refreshStage() => _instance.refreshStage();
 
   @override
-  Future<String> stage() => _instance.stage();
+  Future<VpnStage> stage() => _instance.stage();
 }

--- a/lib/wireguard_flutter_method_channel.dart
+++ b/lib/wireguard_flutter_method_channel.dart
@@ -11,7 +11,7 @@ class WireGuardFlutterMethodChannel extends WireGuardFlutterInterface {
   static const _eventChannel = EventChannel(_eventChannelVpnStage);
 
   @override
-  Stream<String> vpnStageSnapshot() => _eventChannel
+  Stream<String> get vpnStageSnapshot => _eventChannel
       .receiveBroadcastStream()
       .map((event) => event == WireGuardFlutterInterface.vpnDenied
           ? WireGuardFlutterInterface.vpnDisconnected

--- a/lib/wireguard_flutter_method_channel.dart
+++ b/lib/wireguard_flutter_method_channel.dart
@@ -1,16 +1,14 @@
-import 'dart:io';
-
 import 'package:flutter/services.dart';
 
 import 'wireguard_flutter_platform_interface.dart';
 
 class WireGuardFlutterMethodChannel extends WireGuardFlutterInterface {
-  static const String _methodChannelVpnControl =
+  static const _methodChannelVpnControl =
       "billion.group.wireguard_flutter/wgcontrol";
   static const _methodChannel = MethodChannel(_methodChannelVpnControl);
   static const _eventChannelVpnStage =
       'billion.group.wireguard_flutter/wgstage';
-  static const EventChannel _eventChannel = EventChannel(_eventChannelVpnStage);
+  static const _eventChannel = EventChannel(_eventChannelVpnStage);
 
   @override
   Stream<String> vpnStageSnapshot() => _eventChannel
@@ -20,41 +18,28 @@ class WireGuardFlutterMethodChannel extends WireGuardFlutterInterface {
           : event);
 
   @override
-  Future<void> initialize(
-      {String? localizedDescription, String? win32ServiceName}) {
+  Future<void> initialize({required String interfaceName}) {
     return _methodChannel.invokeMethod("initialize", {
-      "localizedDescription": localizedDescription!,
-      "win32ServiceName": win32ServiceName,
-    }).then((value) {
-      stage();
+      "localizedDescription": interfaceName,
+      "win32ServiceName": interfaceName,
     });
   }
 
   @override
-  Future<void> startVpn(
-      {required String serverAddress,
-      required String wgQuickConfig,
-      required String providerBundleIdentifier,
-      String? localizedDescription,
-      String? win32ServiceName}) async {
-    if (Platform.isAndroid || Platform.isIOS || Platform.isMacOS) {
-      await initialize(localizedDescription: localizedDescription);
-    }
+  Future<void> startVpn({
+    required String serverAddress,
+    required String wgQuickConfig,
+    required String providerBundleIdentifier,
+  }) async {
     return _methodChannel.invokeMethod("start", {
       "serverAddress": serverAddress,
       "wgQuickConfig": wgQuickConfig,
       "providerBundleIdentifier": providerBundleIdentifier,
-      "localizedDescription": localizedDescription,
-      "win32ServiceName": win32ServiceName,
-    }).then((value) {
-      stage();
     });
   }
 
   @override
-  Future<void> stopVpn() async {
-    await _methodChannel.invokeMethod('stop');
-  }
+  Future<void> stopVpn() => _methodChannel.invokeMethod('stop');
 
   @override
   Future<void> refreshStage() => _methodChannel.invokeMethod("refresh");

--- a/lib/wireguard_flutter_method_channel.dart
+++ b/lib/wireguard_flutter_method_channel.dart
@@ -11,11 +11,9 @@ class WireGuardFlutterMethodChannel extends WireGuardFlutterInterface {
   static const _eventChannel = EventChannel(_eventChannelVpnStage);
 
   @override
-  Stream<String> get vpnStageSnapshot => _eventChannel
-      .receiveBroadcastStream()
-      .map((event) => event == WireGuardFlutterInterface.vpnDenied
-          ? WireGuardFlutterInterface.vpnDisconnected
-          : event);
+  Stream<VpnStage> get vpnStageSnapshot =>
+      _eventChannel.receiveBroadcastStream().map((event) =>
+          event == VpnStage.denied.code ? VpnStage.disconnected : event);
 
   @override
   Future<void> initialize({required String interfaceName}) {
@@ -45,7 +43,12 @@ class WireGuardFlutterMethodChannel extends WireGuardFlutterInterface {
   Future<void> refreshStage() => _methodChannel.invokeMethod("refresh");
 
   @override
-  Future<String> stage() => _methodChannel.invokeMethod("stage").then(
-        (value) => value ?? WireGuardFlutterInterface.vpnDisconnected,
+  Future<VpnStage> stage() => _methodChannel.invokeMethod("stage").then(
+        (value) => value != null
+            ? VpnStage.values.firstWhere(
+                (stage) => stage.code == value.toString(),
+                orElse: () => VpnStage.disconnected,
+              )
+            : VpnStage.disconnected,
       );
 }

--- a/lib/wireguard_flutter_platform_interface.dart
+++ b/lib/wireguard_flutter_platform_interface.dart
@@ -1,5 +1,5 @@
 abstract class WireGuardFlutterInterface {
-  Stream<String> get vpnStageSnapshot;
+  Stream<VpnStage> get vpnStageSnapshot;
 
   Future<void> initialize({required String interfaceName});
 
@@ -12,21 +12,25 @@ abstract class WireGuardFlutterInterface {
   Future<void> stopVpn();
 
   Future<void> refreshStage();
-  Future<String> stage();
-  Future<bool> isConnected() => stage().then(
-        (value) =>
-            value.toLowerCase() == WireGuardFlutterInterface.vpnConnected,
-      );
+  Future<VpnStage> stage();
+  Future<bool> isConnected() =>
+      stage().then((stage) => stage == VpnStage.connected);
+}
 
-  static const String vpnConnected = "connected";
-  static const String vpnDisconnecting = "disconnecting";
-  static const String vpnDisconnected = "disconnected";
-  static const String vpnWaitConnection = "wait_connection";
-  static const String vpnAuthenticating = "authenticating";
-  static const String vpnReconnect = "reconnect";
-  static const String vpnNoConnection = "no_connection";
-  static const String vpnConnecting = "connecting";
-  static const String vpnPrepare = "prepare";
-  static const String vpnDenied = "denied";
-  static const String vpnExiting = "exiting";
+enum VpnStage {
+  connected('connected'),
+  disconnecting('disconnecting'),
+  disconnected('disconnected'),
+  waitingConnection('wait_connection'),
+  authenticating('authenticating'),
+  reconnect('reconnect'),
+  noConnection('no_connection'),
+  connecting('connecting'),
+  preparing('prepare'),
+  denied('denied'),
+  exiting('exiting');
+
+  final String code;
+
+  const VpnStage(this.code);
 }

--- a/lib/wireguard_flutter_platform_interface.dart
+++ b/lib/wireguard_flutter_platform_interface.dart
@@ -1,17 +1,12 @@
 abstract class WireGuardFlutterInterface {
   Stream<String> vpnStageSnapshot();
 
-  Future<void> initialize({
-    String? localizedDescription,
-    String? win32ServiceName,
-  });
+  Future<void> initialize({required String interfaceName});
 
   Future<void> startVpn({
     required String serverAddress,
     required String wgQuickConfig,
     required String providerBundleIdentifier,
-    String? localizedDescription,
-    String? win32ServiceName,
   });
 
   Future<void> stopVpn();

--- a/lib/wireguard_flutter_platform_interface.dart
+++ b/lib/wireguard_flutter_platform_interface.dart
@@ -1,5 +1,5 @@
 abstract class WireGuardFlutterInterface {
-  Stream<String> vpnStageSnapshot();
+  Stream<String> get vpnStageSnapshot;
 
   Future<void> initialize({required String interfaceName});
 

--- a/lib/wireguard_flutter_platform_interface.dart
+++ b/lib/wireguard_flutter_platform_interface.dart
@@ -19,13 +19,13 @@ abstract class WireGuardFlutterInterface {
 
 enum VpnStage {
   connected('connected'),
+  connecting('connecting'),
   disconnecting('disconnecting'),
   disconnected('disconnected'),
   waitingConnection('wait_connection'),
   authenticating('authenticating'),
   reconnect('reconnect'),
   noConnection('no_connection'),
-  connecting('connecting'),
   preparing('prepare'),
   denied('denied'),
   exiting('exiting');


### PR DESCRIPTION
* Improved installing instructions;
* Improved error handling on Linux;
* Implemented multiple retries on Linux in case of failure;
* Improved overall api:
  * `WireGuardFlutter` is now a singleton. Use `WireGuardFlutter.instance` to get the current wireguard state;
  * `vpnStageSnapshot` is no longer a function. Use `wireguard.vpnStageSnapshot` getter to listen to the wireguard state;
  * removed unused parameters from functions;
* Implement `VpnStage` enum that is used over strings.